### PR TITLE
DOCK3.8.5 Updates

### DIFF
--- a/3D/spliton_docker.py
+++ b/3D/spliton_docker.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import sys
+
+
+def main(delimiter, source, prefix, strip_right=True, start=1):
+    index = start
+    current_handle = None
+    buffer = []
+    try:
+        current_name = "{0}{1:d}".format(prefix, index)
+        current_handle = open(current_name, 'w')
+        for line in source:
+            if strip_right:
+                comp_line = line.rstrip()
+            else:
+                comp_line = line
+
+            if comp_line == delimiter:
+                current_handle.write(''.join(buffer))
+                buffer = []
+                current_handle.close()
+                index += 1
+                current_name = "{0}{1:d}".format(prefix, index)
+                current_handle = open(current_name, 'w')
+                continue
+
+            if comp_line.startswith('#') or not comp_line.strip():
+                continue
+            
+            buffer.append(line)
+
+        current_handle.close()
+        current_handle = None
+    except Exception as e:
+        return 1
+    else:
+        return 0
+    finally:
+        if current_handle is not None:
+            current_handle.close()
+
+if __name__ == '__main__':
+    delimiter = sys.argv[1]
+    if len(sys.argv) > 2:
+        prefix = sys.argv[2]
+    else:
+        prefix = ''
+    sys.exit(main(
+        delimiter=delimiter,
+        source=sys.stdin,
+        prefix=prefix,
+        strip_right=True,
+        start=1
+    ))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:22.04
+
+# Install needed software
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends\
+    build-essential\
+    screen\
+    csh\
+    sudo\
+    zlib1g-dev\
+    openjdk-8-jdk\
+    wget\
+    ncurses-bin\
+    time &&\
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+
+# Copy the required licenses
+COPY --from=jchem_license_folder license.cxl /licenses/jchem-license.cxl
+COPY --from=openeye_license_folder oe_license.txt /licenses/oe_license.txt
+
+# Copy the required folders from the "base" build context (containing the actual software - /mnt/nfs/soft/dock/versions/dock38/pipeline_3D_ligands)
+COPY --from=base /soft/jchem-latest /soft/jchem-latest
+COPY --from=base /soft/dock-latest /soft/dock-latest
+COPY --from=base /soft/corina-latest /soft/corina-latest
+COPY --from=base /soft/openbabel-latest /soft/openbabel-latest
+COPY --from=base /soft/extralibs-latest /soft/extralibs-latest
+COPY --from=base /soft/pyenv-latest /soft/pyenv-latest
+
+# Untar all the required software
+RUN mkdir -p /jchem && tar -xzf /soft/jchem-latest -C /jchem --strip-components=1
+RUN mkdir -p /dock && tar -xzf /soft/dock-latest -C /dock --strip-components=1
+RUN mkdir -p /corina && tar -xzf /soft/corina-latest -C /corina --strip-components=1
+RUN mkdir -p /openbabel && tar -xzf /soft/openbabel-latest -C /openbabel --strip-components=1
+RUN mkdir -p /extralibs && tar -xzf /soft/extralibs-latest -C /extralibs --strip-components=1
+RUN mkdir -p /pyenv && tar -xzf /soft/pyenv-latest -C /pyenv --strip-components=1
+
+# Set the base paths
+ENV CHEMAXONBASE="/jchem"
+ENV DOCKBASE="/dock"
+ENV CORINABASE="/corina"
+ENV OBABELBASE="/openbabel"
+ENV EXTRALIBSBASE="/extralibs"
+
+# Set Licenses
+ENV OE_LICENSE="/licenses/oe_license.txt"
+ENV CHEMAXON_LICENSE_URL="/licenses/jchem-license.cxl"
+
+# Set building pipeline default values
+ENV OMEGA_RMSD="0.5"
+ENV OMEGA_FF="MMFF94Smod"
+ENV OMEGA_MAX_CONFS="600"
+ENV pH_LEVEL="7.4"
+ENV OMEGA_TORLIB="Original"
+ENV OMEGA_ENERGY_WINDOW="12"
+ENV CORINA_MAX_CONFS="1"
+
+
+# Sets other obabel paths
+# TODO: Don't pass this as an arg - extract it from openbabel-latest
+ARG OPENBABEL_VERSION_NUMBER
+ENV BABEL_LIBDIR="${OBABELBASE}/lib/openbabel/${OPENBABEL_VERSION_NUMBER}"
+ENV BABEL_DATADIR="${OBABELBASE}/share/openbabel/${OPENBABEL_VERSION_NUMBER}"
+
+# Points to all the correct software that is needed
+ENV MOLCONVERTEXE="${CHEMAXONBASE}/bin/molconvert"
+ENV CXCALCEXE="${CHEMAXONBASE}/bin/cxcalc"
+ENV OBABELEXE="${OBABELBASE}/bin/obabel"
+ENV CORENAEXE="${CORINABASE}/corina"
+ENV SPLITONEXE="${DOCKBASE}/ligand/3D/spliton_docker.py"
+ENV EMBED_PROTOMERS_3D_EXE="${DOCKBASE}/ligand/3D/embed3d_corina.sh"
+ENV TAUOMERIZE_PROTONATE_EXE="${DOCKBASE}/ligand/protonate/tautprot_cxcalc.sh"
+ENV PROTOMER_STEREOCENTERS_EXE="${DOCKBASE}/ligand/protonate/expand-new-stereocenters.py3.py"
+ENV AMSOLEXE="${DOCKBASE}/ligand/amsol/amsol7.1"
+
+# Set Java home
+ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+
+# Adds required software to paths
+ENV LD_LIBRARY_PATH="${OBABELBASE}/lib:${EXTRALIBSBASE}"
+ENV PATH="${CORINABASE}:${OBABELBASE}/bin:${CHEMAXONBASE}/bin:${DOCKBASE}/bin:${PATH}"
+
+# Link sh to bash (default is dash) b/c all shoichet things are expecting this
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Make sure the python environment is activated when we run the container
+RUN echo '. /pyenv/bin/activate' >> ~/.bashrc

--- a/amsol/make_amsol71_input_docker.py3.py
+++ b/amsol/make_amsol71_input_docker.py3.py
@@ -1,0 +1,166 @@
+import os
+import sys
+import math
+from openeye.oechem import *
+
+VERBOSE = False
+
+#--------------------------------------------------------------------------------------------------------------------------
+
+def read_ZmatMOPAC(zmat_stdin):
+    if VERBOSE:
+        print("")
+        print("just entered read_ZmatMOPAC()")
+        print("")
+
+    # infile_ZmatMOPAC = open(Zmat_file,'r')
+    # lines  =  infile_ZmatMOPAC.readlines()
+
+    ZmatMOPAC_lines = {}
+    line_key_infile = 0
+    line_key_out = 0
+    spl = []
+
+    # loop over all the lines in infile_ZmatMOPAC, whose first 3 lines 
+    # contain information which can be disregarded
+    for line in zmat_stdin:
+         line_key_infile += 1
+         #
+         if ( line_key_infile < 4): # effect: cut the first three lines off. They must be disregarded.
+            pass
+         else:
+            line_key_out += 1 # after cutting the first 3 lines, the fourth line should be the new first line and so forth.
+            #
+            # in the first three lines of the Z-matrix, obabel writes 1 too often. This would rise a non-fatal error message in amsol7.1.
+            # this error message should be avoided, therefore the first three Z-matrix lines should be slightly modified
+            if (line_key_out == 1):
+               spl = line.split()
+               spl[2] = "0" # instead of 1
+               spl[4] = "0" # instead of 1
+               spl[6] = "0" # instead of 1
+               line = "%-2s %10.6f %2d %11.6f %2d %11.6f %2d %5d %3d %3d\n" % (spl[0],float(spl[1]),int(spl[2]),float(spl[3]),int(spl[4]),float(spl[5]),int(spl[6]),int(spl[7]),int(spl[8]),int(spl[9])) 
+            if (line_key_out == 2):
+               spl = line.split()
+               spl[4] = "0" # instead of 1
+               spl[6] = "0" # instead of 1
+               line = "%-2s %10.6f %2d %11.6f %2d %11.6f %2d %5d %3d %3d\n" % (spl[0],float(spl[1]),int(spl[2]),float(spl[3]),int(spl[4]),float(spl[5]),int(spl[6]),int(spl[7]),int(spl[8]),int(spl[9])) 
+            if (line_key_out == 3):
+               spl = line.split()
+               spl[6] = "0" # instead of 1
+               line = "%-2s %10.6f %2d %11.6f %2d %11.6f %2d %5d %3d %3d\n" % (spl[0],float(spl[1]),int(spl[2]),float(spl[3]),int(spl[4]),float(spl[5]),int(spl[6]),int(spl[7]),int(spl[8]),int(spl[9])) 
+               
+            ZmatMOPAC_lines[line_key_out] = line
+    # infile_ZmatMOPAC.close()
+
+    if VERBOSE:
+        print("")
+        print("read_ZmatMOPAC() has finished.")
+        print("")
+
+    return ZmatMOPAC_lines
+
+#-------------------------------------------------------------------------------------------------------------------------
+
+def create_amsol71_inputfile(MoleculeName,ZmatMOPAC_Data):
+
+    if VERBOSE:
+        print("")
+        print("just entered the function create_amsol71_inputfile(): ")
+        print("")
+        print("in the case of problems:")
+        print("Make sure that OpenEye OEChem is installed on your system.")
+        print("")
+
+
+    # slice off the ending .ZmatMOPAC from string_Path_And_NameZmatMOPACFile by using [0:-10]:
+
+    # open a file for the SM5.42R calculation in water solvent:
+    Actual_Amsol71_InputFile_Water = open("%s" % ( "temp.in-wat") ,'w')
+     
+    # open a file for the SM5.42R calculation in hexadecane solvent:
+    Actual_Amsol71_InputFile_Hexadecane = open("%s" % ( "temp.in-hex") ,'w')
+
+    # the AMSOL7.1 input needs the net charge of the molecule (in its specific protonated state):
+    # The net charge will be extracted from temp.mol2 by adding the partial charges in this mol2-file
+    # An OpenEye python tool will be used to do this.
+    # 
+    mol = OEMol()
+    infile = "temp.mol2" 
+    ifs = oemolistream(infile)
+    OEReadMolecule(ifs, mol)
+    # OENetCharge():
+    # Determines the net charge on a molecule. If the molecule has specified partial charges, see OEChem's OEHasPartialCharges function,
+    # this function returns the sum of the partial charges rounded to an integer. 
+    # Otherwise this function returns the sum of the formal charges on each atom of the molecule.
+    netcharge = OENetCharge(mol)
+    if VERBOSE:
+        print("netcharge of molecule in temp.mol2 (sum of partial charges):", netcharge)
+    ifs.close()
+    #
+    # COMMENT: DOCK's mol2amsol.py could also be used to sum up the partial charges in temp.mol2 file!
+
+    # write the AMSOL7.1 keywords for a SM5.42R point calculation in water to the AMSOL7.1 water input-file:
+    Water_Amsol71_SM542R_Keywords = """CHARGE=%s AM1 1SCF TLIMIT=15 GEO-OK SM5.42R\n& SOLVNT=WATER\n""" % netcharge
+    Actual_Amsol71_InputFile_Water.write(Water_Amsol71_SM542R_Keywords)
+
+    # write the AMSOL7.1 keywords for a SM5.42R point calculation in hexadecane to the AMSOL7.1 hexadecane input-file:
+    Hexadecane_Amsol71_SM542R_Keywords = """CHARGE=%s AM1 1SCF TLIMIT=15 GEO-OK SM5.42R\n& SOLVNT=GENORG IOFR=1.4345 ALPHA=0.00 BETA=0.00 GAMMA=38.93\n& DIELEC=2.06 FACARB=0.00 FEHALO=0.00 DEV\n""" % netcharge
+    Actual_Amsol71_InputFile_Hexadecane.write(Hexadecane_Amsol71_SM542R_Keywords)
+
+    # write the name of the currently treated protonated state of the molecule into the AMSOL7.1 file
+    # plus the number of atoms in the molecule
+    if VERBOSE:
+        print("len(ZmatMOPAC_Data) = number of atoms in molecule : ", len(ZmatMOPAC_Data))
+    NumberOfAtomsInMolecule = len(ZmatMOPAC_Data)
+    Molecule_Name_NrAtoms = ( "%s %d\n" % (MoleculeName, NumberOfAtomsInMolecule) )
+    Actual_Amsol71_InputFile_Water.write(Molecule_Name_NrAtoms)
+    Actual_Amsol71_InputFile_Hexadecane.write(Molecule_Name_NrAtoms)
+
+    # write a blank line after the keywords block and the line showing the name of the protonated state of the molecule to the AMSOL7.1 input-files
+    blank_line = "\n"
+    Actual_Amsol71_InputFile_Water.write(blank_line)
+    Actual_Amsol71_InputFile_Hexadecane.write(blank_line)
+
+    # write the lines of the MOPAC Z-matrix to the AMSOL7.1 input-files
+    for line_keys in ZmatMOPAC_Data:
+        Actual_Amsol71_InputFile_Water.write(ZmatMOPAC_Data[line_keys])
+        Actual_Amsol71_InputFile_Hexadecane.write(ZmatMOPAC_Data[line_keys])
+
+    Actual_Amsol71_InputFile_Water.close()
+    Actual_Amsol71_InputFile_Hexadecane.close()
+
+    if VERBOSE:
+        print("")
+        print("just finished the function create_amsol71_inputfile(). ")
+        print("")
+ 
+    return
+
+#-------------------------------------------------------------------------------------------------------------------------
+def main():
+    if VERBOSE:
+        print("")
+        print("just entering main program in make_amsol71_input.py: ")
+        print("")
+
+    if len(sys.argv) != 2: # if no input
+        print(" make_amsol71_input.py needs a ZmatMOPAC file as input.")
+        print(" The ZmatMOPAC file must have been generated by 'obabel ... -o mopin ...' (MOPAC Internals)")
+        print(" Make sure that obabel is installed on your computer !!!")
+        return 
+
+    # path_and_file_ZmatMOPAC    = sys.argv[1]
+    MoleculeName      = sys.argv[1]
+
+    ZmatMOPAC_data = {}
+    ZmatMOPAC_data = read_ZmatMOPAC(sys.stdin)
+
+    if VERBOSE:
+        print("")
+        print("calling create_amsol71_inputfile(): ")
+        print("")
+    create_amsol71_inputfile(MoleculeName,ZmatMOPAC_data)
+
+    return
+#################################################################################################################
+main()

--- a/amsol/process_amsol_mol2.py3.py
+++ b/amsol/process_amsol_mol2.py3.py
@@ -89,7 +89,7 @@ def process_amsol_file(file,outputprefix,watorhex):
          # if (len(linesplit) == 8 and is_int(linesplit[0]) ):
          # AMSOL7.1: table has an additional column "Sigma k cal/(Ang**2)"
          # AMSOL7.1 table: table has 9 columns
-         if (len(linesplit) == 9 and is_int(linesplit[0]) and ( linesplit[4] is not "*")):  ## this gets that per-atom break-down of solvation calculation
+         if (len(linesplit) == 9 and is_int(linesplit[0]) and ( linesplit[4] != "*")):  ## this gets that per-atom break-down of solvation calculation
              file2.write(line)
              alist.append(linesplit)
 

--- a/amsol/process_amsol_mol2.py3.py
+++ b/amsol/process_amsol_mol2.py3.py
@@ -196,13 +196,11 @@ def diff_amsol71_files(atom_listwat,totwat,atom_listhex,tothex,name,numatom,outp
 
     N = len(atom_listwat)
     if len(atom_listwat) != len(atom_listhex):
-        print("Error: len(atom_listwat) != len(atom_listhex):" + str(len(atom_listwat))+" != "+str(len(atom_listhex)))
-        sys.exit()
+        raise ValueError("Error: len(atom_listwat) != len(atom_listhex):" + str(len(atom_listwat))+" != "+str(len(atom_listhex)))
 
     if N != numatom:
         print("\n".join(' '.join(l) for l in atom_listwat))
-        print("Error: len(atom_listwat) != numatom: " + str(N) +" != "+str(numatom))
-        sys.exit()
+        raise ValueError("Error: len(atom_listwat) != numatom: " + str(N) +" != "+str(numatom))
 
     fileline = ''## generate string output to write to a file
     if VERBOSE:
@@ -383,10 +381,8 @@ def modify_charges_mol2_file(mol2file, atom_list_hex, outputprefix):
 
     n = len(atom_list_hex)
     if n != len(mol.atom_list):
-       print("Error: n != len(mol.atom_list) : " + str(n) + " !=" + str(len(mol.atom_list)))
-       exit()
+       raise ValueError("Error: n != len(mol.atom_list) : " + str(n) + " !=" + str(len(mol.atom_list))) 
 
-    
     for i in range(n):
         charge = atom_list_hex[i][2]
         if VERBOSE:

--- a/generate/build_ligands.py
+++ b/generate/build_ligands.py
@@ -299,6 +299,8 @@ with tarfile.open("output.tar.gz", mode='w:gz') as output:
             # new wrapper function added to mol2db2.py, mol2db2_quick
             start = time.time()
             db2_data = mol2db2_quick(db2in_standard, solvfile="solv/" + str(mol.idx) + "/output.solv", clashfile=DOCKBASE + "/ligand/mol2db2/clashfile.txt")
+            # Remove the protomer ID inside the DB2 file itself
+            db2_data = db2_data[:2] + f"{mol.name.split('.')[0]:16}" + db2_data[18:]
             db2_all_data += db2_data
             t_db2_tot += (time.time() - start)
 

--- a/generate/build_ligands_docker.py
+++ b/generate/build_ligands_docker.py
@@ -377,6 +377,18 @@ with tarfile.open("bundle.db2.tgz", mode='w:gz') as output:
                 failed_strain_db2 = True
                 break
 
+            # Remove the protomer ID inside the DB2 file itself
+            db2_data = db2_data[:2] + f"{mol.name.split('.')[0]:16}" + db2_data[18:]
+
+            # Add the neutral smiles to the DB2
+            shortname = mol.name.split('.')[0]
+            neutral_smiles = neutral_smiles_dict[shortname] if shortname in neutral_smiles_dict else "N/A"
+            if len(neutral_smiles) > 76:
+                neutral_smiles = "smilestoolong"
+            db2_data_list = db2_data.split('\n')
+            db2_data_list[2] = f"M {neutral_smiles:76}"
+            db2_data = '\n'.join(db2_data_list)
+
             db2_all_data += db2_data
             t_db2_tot += (time.time() - start)
 
@@ -386,14 +398,6 @@ with tarfile.open("bundle.db2.tgz", mode='w:gz') as output:
             continue
 
         start = time.time()
-        db2_all_data = db2_all_data[:2] + f"{mol.name.split('.')[0]:16}" + db2_all_data[18:]
-        shortname = mol.name.split('.')[0]
-        neutral_smiles = neutral_smiles_dict[shortname] if shortname in neutral_smiles_dict else "N/A"
-        if len(neutral_smiles) > 76:
-            neutral_smiles = "smilestoolong"
-        db2_all_data_list = db2_all_data.split('\n')
-        db2_all_data_list[2] = f"M {neutral_smiles:76}"
-        db2_all_data = '\n'.join(db2_all_data_list)
         write_to_tarball(output, db2_all_data.encode('utf-8'), name=mol_fullname + '.db2')
         successfully_built.add(shortname)
 

--- a/generate/build_ligands_docker.py
+++ b/generate/build_ligands_docker.py
@@ -352,7 +352,6 @@ with tarfile.open("bundle.db2.tgz", mode='w:gz') as output:
                 output.close()
                 sys.exit()
 
-            # TODO: nice-to-have Add neutral smiles to db2
             # TODO: Put the microspecies percentage in the db2
 
             db2in_standard, db2in_strain = db2in
@@ -387,7 +386,7 @@ with tarfile.open("bundle.db2.tgz", mode='w:gz') as output:
             continue
 
         start = time.time()
-        ddb2_all_data = db2_all_data[:2] + f"{mol.name.split('.')[0]:16}" + db2_all_data[18:]
+        db2_all_data = db2_all_data[:2] + f"{mol.name.split('.')[0]:16}" + db2_all_data[18:]
         shortname = mol.name.split('.')[0]
         neutral_smiles = neutral_smiles_dict[shortname] if shortname in neutral_smiles_dict else "N/A"
         if len(neutral_smiles) > 76:

--- a/generate/build_ligands_docker.py
+++ b/generate/build_ligands_docker.py
@@ -1,0 +1,465 @@
+# author: Benjamin Tingle 8/17/2020
+import time
+
+import sys
+import os
+
+DOCKBASE=os.environ['DOCKBASE']
+sys.path.append(DOCKBASE + "/ligand/mol2db2_py3_strain")
+sys.path.append(DOCKBASE + "/ligand/strain")
+sys.path.append(DOCKBASE + "/ligand/omega")
+
+import subprocess
+import shutil
+import tarfile
+import io
+import openbabel
+import signal
+from openeye import oechem
+
+
+from mol2 import Mol2
+from hydrogens import count_hydrogens
+from mol2db2 import mol2db2_quick
+from Torsion_Strain import calc_strain
+from TL_Functions import Mol2MolSupplier_noF
+from omega import generate_conformations
+
+
+start = time.time()
+
+# class for handling the conversion between Mol2 classes needed by various stages of the pipeline
+class MultiMol2:
+    def __init__(self, data):
+        self.data = data
+        self.dockFormat = Mol2(mol2text=[line+'\n' for line in data.split('\n')])
+        ifs = oechem.oemolistream()
+        ifs.SetFormat(oechem.OEFormat_MOL2)
+        ifs.openstring(data)
+        ms = [oechem.OEMol(m) for m in ifs.GetOEMols()]
+        self.oeFormat = ms[0]
+        ifs.close() # even though we're just reading from memory, i'm still paranoid this needs to be called
+    @staticmethod
+    def oe2str(oemol):
+        ofs = oechem.oemolostream()
+        ofs.SetFormat(oechem.OEFormat_MOL2)
+        ofs.openstring()
+        oechem.OEWriteMolecule(ofs, oemol)
+        s = ofs.GetString().decode('utf-8')
+        ofs.close()
+        return s
+    @staticmethod
+    def oe2dock(oemol):
+        s = MultiMol2.oe2str(oemol).split('\n')
+        return Mol2(mol2text=[line+'\n' for line in s])
+    @staticmethod
+    def oe2supplier(oemol):
+        s = MultiMol2.oe2str(oemol)
+        return Mol2MolSupplier_noF(s) # new function added to TL_Functions.py, creates a mol supplier object without reading from a file
+
+
+# rewrites the name of a mol2, only used when CORINA_CONFS > 1 to denote different corina conformations
+def rewrite_mol2_name(mol2fn, name):
+    mol2_f = open(mol2fn, 'r')
+    mol2_t = open(mol2fn + '.t', 'w')
+    i = 0
+    for line in mol2_f:
+        i += 1
+        if i == 2:
+            mol2_t.write(name + '\n')
+        else:
+            mol2_t.write(line)
+    mol2_f.close()
+    mol2_t.close()
+    os.rename(mol2fn + '.t', mol2fn)
+
+def write_to_tarball(ball, data, name):
+    tar = tarfile.TarInfo(name=name)
+    tar.size = len(data)
+    ball.addfile(tar, io.BytesIO(data))
+
+
+def load_neutral_smiles_dict(input_file='/data/input.smi'):
+    smiles_dict = dict()
+    with open(input_file) as f:
+        for line1 in f:  # using line1, name1 because of global variable names... -.-
+            smiles1, name1 = line1.split()
+            if name1 in smiles_dict:
+                raise ValueError(f"Name {name1} is not unique.")
+            smiles_dict[name1] = smiles1
+    return smiles_dict
+
+
+# TODO: Fix the microspecies percentage being in the output name (ex. ZINC.100.db2.gz). Should be in file name (as .0, .1, etc) but not inside the db2
+
+
+neutral_smiles_dict = load_neutral_smiles_dict()
+
+# TODO: add the neutral smiles to the "protonated flat" list
+protonated_flat = []
+prot_ids = {}
+for line in sys.stdin:
+    smiles, name = line.split()[:2]
+    if name in prot_ids:
+        prot_ids[name] += 1
+    else:
+        prot_ids[name] = 0
+    prot_id = prot_ids[name]
+    protonated_flat.append((name + "." + str(prot_id), smiles, int(prot_id)))
+
+t_upstream = (time.time() - start)
+
+start = time.time()
+
+# sort the protonated list for the next step
+protonated_flat = sorted(protonated_flat, key=lambda x:x[0])
+
+# when protomers get expanded, expanded protomers will not be assigned a unique id
+# e.g if a new protomer was expanded from ZINC123.1, the new protomer will still be named ZINC123.1
+# we fix this here
+# protomers_aug = open(os.getcwd() + "/protomers_in_corina", 'w')
+corina_input = ""
+name_prev = None
+protonated_flat_aug = []
+for protomer in protonated_flat:
+    name = protomer[0]
+    if name_prev == name:
+        protid = int(name.split('.')[-1])
+        name = '.'.join(name.split('.')[:-1] + [str(protid + 1)])
+        corina_input += protomer[1] + " " + name + "\n"
+        # protomers_aug.write(protomer[1] + " " + name + "\n")
+        protonated_flat_aug.append((name, protomer[1], protid + 1))
+        name_prev = name
+    else:
+        corina_input += protomer[1] + " " + name + "\n"
+        # protomers_aug.write(protomer[1] + " " + name + "\n")
+        protonated_flat_aug.append(protomer)
+        name_prev = name
+        dup_protid_cnt = 0
+# protomers_aug.close()
+protonated_flat = protonated_flat_aug
+
+t_corina_aug = time.time() - start
+
+start = time.time()
+
+# initialize working directories
+os.makedirs("3d", exist_ok=True)
+os.makedirs("solv", exist_ok=True)
+
+# read in number of corina conformations to (attempt to) generate per protomer
+corinaconfs = int(os.environ["CORINA_MAX_CONFS"])
+
+# create 3d embeddings for protomers
+# subprocess.call([DOCKBASE + "/ligand/3D/embed3d_corina.sh", protomers_aug.name, "-o", "3d/"])
+# Brendan rewrite in the function here to speed things up (avoid spawing sh script which i think can cause slow downs with lots of workers)
+corina_result = subprocess.run([f'{os.environ["CORENAEXE"]}', "-i", "t=smiles", "-o", "t=mol2", "-d", "rc,flapn,de=6,mc=1,wh"], input=corina_input, text=True, capture_output=True)
+subprocess.run([f'{os.environ["SPLITONEXE"]}', "#\tEnd of record", "3d/"], input=corina_result.stdout, text=True)
+
+t_embed3d = time.time() - start
+
+start = time.time()
+# remove size zero files created by spliton.py (not sure why it does this)
+# (The reason it does this is because when you get to the last delimeter it opens another file but then closes it because you got to end)
+with subprocess.Popen(["find", "3d", "-size", "0"], stdout=subprocess.PIPE) as proc:
+    subprocess.call(["xargs", "rm"], stdin=proc.stdout)
+
+t_find = time.time() - start
+
+start = time.time()
+# find the names of every mol that succeeded corina 3d embedding
+corina_success = []
+for mol2fn in os.listdir("3d"):
+    with subprocess.Popen(["awk", "{if (NR == 2) print $0}", "3d/" + mol2fn], stdout=subprocess.PIPE) as proc:
+        mol_name = proc.stdout.read().strip().decode('utf-8')
+        corina_success.append((mol_name, mol2fn))
+# sort the list by mol number so that it lines up with the list of protonated mols
+corina_success = sorted(corina_success, key=lambda x:int(x[1]))
+t_find_success = time.time() - start 
+
+
+start = time.time()
+# identify which molecules succeeded, assign corina confs numbers (if CORINA_CONFS > 1)
+corina_success_names = [c[0] for c in corina_success]
+protonated_success = []
+total_success = len(protonated_flat)
+total_protomers = len(protonated_flat)
+
+for p in protonated_flat:
+    try:
+        ci = corina_success_names.index(p[0])
+    except:
+        total_success -= 1
+        continue
+
+    confnum = 0
+    while ci >= 0:        
+        mol_name, mol2fn = corina_success[ci]
+        corina_success_names.pop(ci)
+        corina_success.pop(ci)
+        if corinaconfs > 1:
+            mol_name = '.'.join([p[0], str(confnum)])
+            p1 = (mol_name, p[1], p[2])
+            rewrite_mol2_name("3d/" + mol2fn, mol_name)
+            protonated_success.append((mol2fn, p1))
+        else:
+            protonated_success.append((mol2fn, p))
+        confnum += 1
+        try:
+            ci = corina_success_names.index(p[0])
+        except:
+            ci = -1
+protonated_flat = protonated_success
+t_change_success = time.time() - start
+
+# if corinaconfs > 1:
+#     print("{} / {} protomers built successfully, {} conformations generated (avg {} confs per protomer, mc={})".format(total_success, total_protomers, len(protonated_flat), len(protonated_flat) / total_success, corinaconfs))
+# else:
+#     print("{} / {} protomers built successfully".format(total_success, total_protomers))
+
+# t_corina = (time.time() - start)
+
+start = time.time()
+
+SOLV_TIMEOUT = 60
+
+# read mol2 data into memory
+mol2_data = []
+solv_data = []
+t_solvation = 0
+failed_solvation_names = set()
+for mol2, protomer in protonated_flat:
+    name, smiles, prot_id = protomer
+    if name in failed_solvation_names:
+        continue
+    # calculate solvation as we go along
+    if not os.path.isdir("solv/" + str(mol2)):
+        subprocess.call(["mkdir", "solv/" + str(mol2)])
+        # mol2_fullname = '.'.join([name, 'mol2'])
+        subprocess.call(["ln", "-svfn", os.getcwd() + "/3d/" + str(mol2), "solv/" + str(mol2) + "/temp.mol2"])
+        os.chdir("solv/" + str(mol2))
+        start = time.time()
+        # This is replacing the old calc_solvation.csh call that I found had lots of overhead with many workers (should take ~15 sec but was getting ~30)
+        # Run obabel
+        obabel_result = subprocess.run([os.environ["OBABELEXE"], "-i", "mol2", "temp.mol2", "-o", "mopin"], capture_output=True, text=True)
+        obabel_output = obabel_result.stdout
+        # process input
+        subprocess.run(["python", f'{os.environ["DOCKBASE"]}/ligand/amsol/make_amsol71_input_docker.py3.py', name], input=obabel_output, text=True)
+        # run amsol
+        with open('temp.in-wat', 'r') as infile, open('temp.o-wat', 'w') as outfile:
+            # Some molecules break or make amsol take forever - calc_solvation.csh had a 1m timeout to stop this so I have one here too
+            try:
+                subprocess.run([os.environ["AMSOLEXE"]], stdin=infile, stdout=outfile, stderr=subprocess.PIPE, text=True, timeout=SOLV_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                failed_solvation_names.add(name)
+                os.chdir("../..")
+                continue
+        with open('temp.in-hex', 'r') as infile, open('temp.o-hex', 'w') as outfile:
+            try:
+                subprocess.run([os.environ["AMSOLEXE"]], stdin=infile, stdout=outfile, stderr=subprocess.PIPE, text=True, timeout=SOLV_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                failed_solvation_names.add(name)
+                os.chdir("../..")
+                continue
+        # process output
+        try:
+            subprocess.run(["python", f'{os.environ["DOCKBASE"]}/ligand/amsol/process_amsol_mol2.py3.py', "temp.o-wat", "temp.o-hex", "temp.mol2", "output"], check=True, capture_output=True, text=True)
+        except Exception as e:
+            print(f'processing amsol output failed with exception: {e}')
+            failed_solvation_names.add(name)
+            os.chdir("../..")
+            continue
+
+        os.chdir("../..")
+        t_solvation += (time.time() - start)
+
+    if os.path.isfile("solv/" + str(mol2) + "/output.solv"):
+
+        with open("solv/" + str(mol2) + "/output.solv") as solv:
+            solv_data.append(solv.read())
+
+        with open("solv/" + str(mol2) + "/output.mol2") as mol2_f:
+            mol = MultiMol2(mol2_f.read())
+            mol.idx = mol2
+            mol.name = name
+            mol.smiles = smiles
+            mol.prot_id = prot_id
+            mol.charge = int(float(solv_data[-1].split('\n')[0].split()[2]))
+            mol2_data.append(mol)
+
+
+
+# t_solvation = (time.time() - start)
+# print("{} / {} solvation successful".format(len(mol2_data), len(protonated_flat)))
+
+start = time.time()
+
+stop = False
+
+with tarfile.open("bundle.db2.tgz", mode='w:gz') as output:
+
+    # make sure to handle the SIGUSR1 interrupt so we properly close the tarfile
+    def timeup_handler(signum, frame):
+        global stop
+        # print("received SIGUSR1 : build_ligands.py")
+        stop = True
+        #output.close()
+        #sys.exit(1)
+
+    signal.signal(10, timeup_handler)
+    signal.signal(2, timeup_handler)
+
+
+    t_calc_strain = t_add_strain = t_db2_tot = t_omega_tot = t_count_h = t_db2ins = t_convert_write = 0
+    
+    skip_omega = True if os.getenv("SKIP_OMEGA") else False    
+
+    t_get_to_loop = (time.time() - start)
+
+    successfully_built = set()
+
+    for i, mol in enumerate(mol2_data):
+        if mol.name in failed_solvation_names:
+            continue
+        start = time.time()
+        mol_fullname = '.'.join([mol.name, chr(mol.charge+78)])
+
+        # new wrapper function added to hydrogens.py, count_hydrogens
+        h = count_hydrogens(mol.dockFormat)
+        t_count_h += (time.time() - start)
+        # generate_conformations is a new function in the new file omega.py
+        if not skip_omega:
+            start = time.time()
+            try:
+                db2ins, fails = generate_conformations(mol.oeFormat, h)
+            except Exception as e:
+                print(f'Mol {mol.name} failed omega conformer generation with exception: {e}')
+                continue
+            t_omega_tot += (time.time() - start)
+            assert(fails == 0)
+            start = time.time()
+            db2ins = list(map(lambda mo:(MultiMol2.oe2dock(mo), MultiMol2.oe2supplier(mo)), db2ins))
+            t_db2ins += (time.time() - start)
+        else:
+            start = time.time()
+            db2ins = [MultiMol2.oe2dock(mol.oeFormat), MultiMol2.oe2supplier(mol.oeFormat)]
+            t_db2ins += (time.time() - start)
+
+        db2_all_data = ""
+        failed_strain_db2 = False
+        for j, db2in in enumerate(db2ins):
+            if stop == True:
+                output.close()
+                sys.exit()
+
+            # TODO: nice-to-have Add neutral smiles to db2
+            # TODO: Put the microspecies percentage in the db2
+
+            db2in_standard, db2in_strain = db2in
+            # new wrapper function added to Torsion_Strain.py, calc_strain
+            start = time.time()
+            try:
+                tE, pE = calc_strain(*db2in_strain)
+            except Exception as e:
+                print(f"Mol {mol.name} failed strain calculation with exception: {e}")
+                failed_strain_db2 = True
+                break
+            t_calc_strain += (time.time() - start)
+            # new utility function added to mol2.Mol2 class, addStrainInfo
+            start = time.time()
+            db2in_standard.addStrainInfo(tE, pE)
+            t_add_strain += (time.time() - start)
+            # new wrapper function added to mol2db2.py, mol2db2_quick
+            start = time.time()
+            try:
+                db2_data = mol2db2_quick(db2in_standard, solvfile="solv/" + str(mol.idx) + "/output.solv", clashfile=DOCKBASE + "/ligand/mol2db2/clashfile.txt")
+            except Exception as e:
+                print(f"Mol {mol.name} failed mol2db2_quick with exception: {e}")
+                failed_strain_db2 = True
+                break
+
+            db2_all_data += db2_data
+            t_db2_tot += (time.time() - start)
+
+            # print(j+1, '/', len(db2ins))
+
+        if failed_strain_db2:
+            continue
+
+        start = time.time()
+        ddb2_all_data = db2_all_data[:2] + f"{mol.name.split('.')[0]:16}" + db2_all_data[18:]
+        shortname = mol.name.split('.')[0]
+        neutral_smiles = neutral_smiles_dict[shortname] if shortname in neutral_smiles_dict else "N/A"
+        if len(neutral_smiles) > 76:
+            neutral_smiles = "smilestoolong"
+        db2_all_data_list = db2_all_data.split('\n')
+        db2_all_data_list[2] = f"M {neutral_smiles:76}"
+        db2_all_data = '\n'.join(db2_all_data_list)
+        write_to_tarball(output, db2_all_data.encode('utf-8'), name=mol_fullname + '.db2')
+        successfully_built.add(shortname)
+
+        t_convert_write += (time.time() - start)
+        start = time.time()
+        t_convert_write += (time.time() - start)
+
+    start = time.time()
+    t_convert_write += (time.time() - start)
+
+    failed_out = open('/data/failed_to_build.smi', 'w')
+    success_out = open('/data/successfully_built.smi', 'w')
+    for name in neutral_smiles_dict:
+        if name not in successfully_built:
+            failed_out.write(f"{neutral_smiles_dict[name]} {name}\n")
+        else:
+            success_out.write(f"{neutral_smiles_dict[name]} {name}\n")
+    failed_out.close()
+    success_out.close()
+
+
+# Everything is run in /tmp so put the final output to the correct places
+start = time.time()
+shutil.move('bundle.db2.tgz', '/data/bundle.db2.tgz')
+
+t_cleanup = time.time() - start
+
+print(
+    "elapsed times:\n"
+    "upstream: {}\n"
+    "num_for_solvation: {}\n"
+    "solvation: {}\n"
+    "calc strain: {}\n"
+    "add strain: {}\n"
+    "db2: {}\n"
+    "omega: {}\n"
+    "corina_aug: {}\n"
+    "corina_embed3d: {}\n"
+    "corina_find: {}\n"
+    "corina_find_success: {}\n"
+    "corina_change_success: {}\n"
+    "to_to_loop: {}\n"
+    "count H: {}\n"
+    "db2ins: {}\n"
+    "con/write: {}\n"
+    "cleanup_folders: {}".format(
+        t_upstream,
+        len(protonated_flat),
+        t_solvation,
+        t_calc_strain,
+        t_add_strain,
+        t_db2_tot,
+        t_omega_tot,
+        t_corina_aug,
+        t_embed3d,
+        t_find,
+        t_find_success,
+        t_change_success,
+        t_get_to_loop,
+        t_count_h,
+        t_db2ins,
+        t_convert_write,
+        t_cleanup
+    )
+)
+        
+
+# that's all!

--- a/generate/build_ligands_docker.py
+++ b/generate/build_ligands_docker.py
@@ -90,9 +90,6 @@ def load_neutral_smiles_dict(input_file='/data/input.smi'):
     return smiles_dict
 
 
-# TODO: Fix the microspecies percentage being in the output name (ex. ZINC.100.db2.gz). Should be in file name (as .0, .1, etc) but not inside the db2
-
-
 neutral_smiles_dict = load_neutral_smiles_dict()
 
 # TODO: add the neutral smiles to the "protonated flat" list

--- a/omega/omega.py
+++ b/omega/omega.py
@@ -220,8 +220,8 @@ def generate_conformations(mol, h):
     oechem.OEDetermineComponents(mol)
     count, ringlist = oechem.OEDetermineRingSystems(mol)
     
-    print(ringlist)
-    print(count)
+    # print(ringlist)
+    # print(count)
     #rcf = open('ring_count', 'w')
     #rcf.write('%d\n' % count)
     #rcf.close()
@@ -245,7 +245,7 @@ def generate_conformations(mol, h):
         for i in range(1, count+1):
 
             pred.SelectPart(i)
-            print(pred)
+            # print(pred)
 
             #ringmol = oechem.OEMol()
             molcopy = oechem.OEMol(mol)

--- a/omega/omega.py
+++ b/omega/omega.py
@@ -183,8 +183,7 @@ def generate_conformations(mol, h):
 
     numHs = h
     if numHs > 5:
-        print("Refusing to build conformations with > 5 rotatable hydrogens")
-        sys.exit(-1)
+        raise ValueError("Refusing to build conformations with >5 rotatable hydrogens")
     if numHs >= 4:
         ##logging.warn("4-5 Rotatable hydrogens  reported. Reducing confs by a factor of 30")
         limitConfs = limitConfs // 30

--- a/omega/omega.py
+++ b/omega/omega.py
@@ -75,9 +75,9 @@ def set_SliceEnsembleOpts_defaults(SliceEnsembleOpts, limitConfs=200, energyWind
         #SliceEnsembleOpts.SetRMSRange("0.2, 0.3, 0.4, 0.5")
         SliceEnsembleOpts.SetRMSRange("0.1, 0.2, 0.3, 0.4")
     # Sets flag if energy of the conformers should be used for slicing of conformers. This flag should be turned on if energies are optimized energies of the conformers. Default: False
-    # SliceEnsembleOpts.SetSliceByEnergy(False)
+    SliceEnsembleOpts.SetSliceByEnergy(False)
     # Sets the Energy threshold (Difference between energies) below which two conformers are treated as duplicates. This value is only meaningful when SetSliceByEnergy is set to true. Default: 0.01.
-    # SliceEnsembleOpts.SetEnergyThreshold(0.01)
+    SliceEnsembleOpts.SetEnergyThreshold(0.01)
 
 #https://docs.eyesopen.com/toolkits/cpp/oefftk/OEFFClasses/OEMMFFSheffieldOptions.html#OEFF::OEMMFFSheffieldOptions
 def set_ffOpts_defaults(ffOpts,ffType="MMFF94Smod"):
@@ -214,7 +214,7 @@ def generate_conformations(mol, h):
     set_ffOpts_defaults(ffOpts,ffType)
     #logging.warning('Setting ffType to %s' % (ffType))
     ff = oeff.OEMMFFSheffield(ffOpts)
-    # tordriver.SetForceField(ff)
+    tordriver.SetForceField(ff)
     omegaFixOpts = oeomega.OEConfFixOptions()
 
     oechem.OEDetermineComponents(mol)

--- a/strain/TL_Functions.py
+++ b/strain/TL_Functions.py
@@ -57,6 +57,7 @@ import os #For the function to read in the molecules from the .mol2 file
 import numpy as np #For arrays and NumPy function
 from math import sqrt, atan2, pi #For calculating dihedral angles
 from math import ceil #Ceiling function
+from numpy.linalg import norm
 
 
 # Import the XML file, using this as a guide:
@@ -299,13 +300,22 @@ def dihedral(a_1, a_2, a_3, a_4):
     b_2 = a_3 - a_2
     b_3 = a_4 - a_3
 
-    n_1 = unit(np.cross(b_1, b_2))
-    n_2 = unit(np.cross(b_2, b_3))
+    n_1 = np.cross(b_1, b_2)
+    # Only normalize vector if its not length 0
+    if norm(n_1) != 0:
+        n_1 = unit(n_1)
+
+    n_2 = np.cross(b_2, b_3)
+    if norm(n_2) != 0:
+        n_2 = unit(n_2)
 
     # Imagine the first atom (a_1) is above the middle bond (from a_2 to a_3),
     # so that b_1 points downward. Then n_1 points out of the page
 
-    m = unit(np.cross(n_1, b_2))
+    m = np.cross(n_1, b_2)
+    if norm(m) != 0:
+        m = unit(m)
+        
     # I moved the normalization to be after the cross product. Moving
     # the normalization should not change the end result because the cross
     # product commutes with scalar multiplication and ||n_1|| = 1

--- a/submit/build-docker.sh
+++ b/submit/build-docker.sh
@@ -1,0 +1,3 @@
+source /pyenv/bin/activate
+cd /tmp
+$TAUOMERIZE_PROTONATE_EXE -H 7.4 < /data/input.smi | $PROTOMER_STEREOCENTERS_EXE | python ${DOCKBASE}/ligand/generate/build_ligands_docker.py

--- a/submit/submit_building_docker.py
+++ b/submit/submit_building_docker.py
@@ -7,6 +7,7 @@ INPUT_SMI_NAME = "input.smi"
 
 
 SGE_TEMPLATE = """#!/bin/bash
+#$ -S /bin/bash
 #$ -cwd
 #$ -j y
 #$ -o {log_folder}
@@ -14,7 +15,7 @@ SGE_TEMPLATE = """#!/bin/bash
 #$ -l h_rt={h_rt}
 #$ -l mem_free=2.5G
 
-INDIR={input_folder}
+export INDIR="{input_folder}"
 {command}
 """
 
@@ -26,7 +27,7 @@ SLURM_TEMPLATE = """#!/bin/bash
 
 TMPDIR=$(mktemp -d /scratch/${{USER}}/job_${{SLURM_JOB_ID}}_${{SLURM_ARRAY_TASK_ID}}_XXXXXX)
 trap "rm -rf $TMPDIR" EXIT
-export INDIR="/mnt/nfs/exk/work/bwhall61/building_github/test/building_output/${{SLURM_ARRAY_TASK_ID}}"
+export INDIR="{input_folder}"
 newgrp docker << EOF
 {command}
 EOF
@@ -34,7 +35,7 @@ EOF
 
 APPTAINER_COMMAND = "apptainer exec --cleanenv --no-mount tmp --bind ${{INDIR}}:/data --bind ${{TMPDIR}}:/tmp {container_path_or_name} bash /dock/ligand/submit/build-docker.sh"
 
-DOCKER_COMMAND = "docker run --rm -u $(id -u):$(id -g) --mount type=bind,source=${{INDIR}},target=/data --mount type=bind,source=${{TMPDIR}},target=/tmp {container_path_or_name} bash /dock/ligand/submit/build-docker.sh"
+DOCKER_COMMAND = "docker run --rm -u $(id -u):$(id -g) -v ${{INDIR}}:/data -v ${{TMPDIR}}:/tmp {container_path_or_name} bash /dock/ligand/submit/build-docker.sh"
 
 
 def make_building_array_job(input_file, output_folder, bundle_size, minutes_per_mol, building_config_file,

--- a/submit/submit_building_docker.py
+++ b/submit/submit_building_docker.py
@@ -1,0 +1,165 @@
+import argparse
+import os
+from tqdm import tqdm
+
+
+INPUT_SMI_NAME = "input.smi"
+
+
+SGE_TEMPLATE = """#!/bin/bash
+#$ -cwd
+#$ -j y
+#$ -o {log_folder}
+#$ -t 1-{count}
+#$ -l h_rt={h_rt}
+#$ -l mem_free=2.5G
+
+INDIR={input_folder}
+{command}
+"""
+
+SLURM_TEMPLATE = """#!/bin/bash
+#SBATCH --output={log_folder}/slurm-%A_%a.out
+#SBATCH --array=1-{count}
+#SBATCH --time={h_rt}
+#SBATCH --mem=2500M
+
+TMPDIR=$(mktemp -d /scratch/${{USER}}/job_${{SLURM_JOB_ID}}_${{SLURM_ARRAY_TASK_ID}}_XXXXXX)
+trap "rm -rf $TMPDIR" EXIT
+export INDIR="/mnt/nfs/exk/work/bwhall61/building_github/test/building_output/${{SLURM_ARRAY_TASK_ID}}"
+newgrp docker << EOF
+{command}
+EOF
+"""
+
+APPTAINER_COMMAND = "apptainer exec --cleanenv --no-mount tmp --bind ${{INDIR}}:/data --bind ${{TMPDIR}}:/tmp {container_path_or_name} bash /dock/ligand/submit/build-docker.sh"
+
+DOCKER_COMMAND = "docker run --rm -u $(id -u):$(id -g) --mount type=bind,source=${{INDIR}},target=/data --mount type=bind,source=${{TMPDIR}},target=/tmp {container_path_or_name} bash /dock/ligand/submit/build-docker.sh"
+
+
+def make_building_array_job(input_file, output_folder, bundle_size, minutes_per_mol, building_config_file,
+                            array_job_name, skip_name_check, scheduler, container_software, container_path_or_name):
+    all_ids = set()
+    count = 1
+    buffer = []
+    os.makedirs(output_folder, exist_ok=True)
+    with open(input_file) as f:
+        for i,line in tqdm(enumerate(f), desc="Mols processed"):
+            ll = line.split()
+            if len(ll) != 2:
+                raise ValueError(f"Input file {input_file} should have two columns: smiles and name (unique) in line {i+1}")
+            smiles, name = ll
+            if not skip_name_check and name in all_ids:
+                raise ValueError(f"Name {name} is not unique.")
+            if len(name) > 16:
+                raise ValueError(f"Name {name} is too long. Max length is 16 characters.")
+            if '.' in name:
+                raise ValueError(f"Name {name} contains a period, which is not allowed.")
+            if not skip_name_check:
+                all_ids.add(name)
+            buffer.append((smiles, name))
+            if len(buffer) == bundle_size:
+                output_one_list(buffer, count, output_folder)
+                count += 1
+                buffer = []
+    if buffer:
+        output_one_list(buffer, count, output_folder)
+    else:
+        count -= 1
+    if count > 100000:
+        raise ValueError(f"Too many molecules to build (array has {count} jobs, max is 100k). " +
+                         "Increase bundle size or split the input file.")
+    if count < 1000:
+        print(f"WARNING: only {count} jobs in array. If you want your results fast, consider decreasing bundle size " +
+              "to get more parallelization.")
+
+    write_job_array_script(output_folder, count, bundle_size, minutes_per_mol, building_config_file, array_job_name, scheduler, container_software, container_path_or_name)
+
+def write_job_array_script(output_folder, count, bundle_size, minutes_per_mol, building_config_file, 
+                           array_job_name, scheduler, container_software, container_path_or_name):
+    
+    if building_config_file is not None:
+        raise ValueError("Custom building config files are not yet supported")
+    
+    log_folder = os.path.join(output_folder, "logs")
+    os.makedirs(log_folder, exist_ok=True)
+
+    if container_software == "docker":
+        command = DOCKER_COMMAND.format(
+            container_path_or_name=container_path_or_name
+        )
+    elif container_software == "apptainer":
+        command = APPTAINER_COMMAND.format(
+            container_path_or_name=container_path_or_name
+        )
+
+    if scheduler == "sge":
+        script = SGE_TEMPLATE.format(
+            log_folder=log_folder,
+            count=count,
+            h_rt=minutes_to_h_rt(minutes_per_mol * bundle_size),
+            input_folder=os.path.join(os.getcwd(),output_folder, "${SGE_TASK_ID}"),
+            command=command,
+        )
+    elif scheduler == "slurm":
+        script = SLURM_TEMPLATE.format(
+            log_folder=log_folder,
+            count=count,
+            h_rt=minutes_to_h_rt(minutes_per_mol * bundle_size),
+            input_folder=os.path.join(os.getcwd(),output_folder, "${SLURM_ARRAY_TASK_ID}"),
+            command=command,
+        )
+    else:
+        raise ValueError("Only SGE and Slurm are supported")
+
+    with open(array_job_name, "w") as f:
+        f.write(script)
+    print(f"Array job script written to {array_job_name}")
+
+
+def minutes_to_h_rt(minutes):
+    if minutes > 60*24*14:
+        raise ValueError("Requested time is too long (max is 14 days). Reduce bundle size or minutes_per_mol.")
+    hours = minutes // 60
+    remaining_minutes = int(minutes % 60)
+    return f"{hours}:{remaining_minutes:02d}:00"
+
+
+def output_one_list(buffer, count, output_folder):
+    subfolder = os.path.join(output_folder, f"{count}")
+    os.makedirs(subfolder, exist_ok=True)
+    with open(os.path.join(subfolder, INPUT_SMI_NAME), "w") as f:
+        for smiles, name in buffer:
+            f.write(f"{smiles} {name}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Arguments for submitting a building array job from a single .smi file.")
+
+    parser.add_argument("input_file", type=str, help="The input .smi file to build.")
+    parser.add_argument("--scheduler", type=str, default='slurm', help="Which scheduler to use")
+    parser.add_argument("--container_software", type=str, default="docker", help="Are we using docker or apptainer")
+    parser.add_argument("--container_path_or_name", type=str, default="building_pipeline", help="Path to image for apptainer or name for docker")
+    parser.add_argument("--output_folder", type=str, default='building_output',
+                        help="The output folder to store the building results.")
+    parser.add_argument("--bundle_size", type=int, default=1000,
+                        help="The number of molecules to build per .db2.tgz bundle")
+    parser.add_argument("--minutes_per_mol", type=float, default=3,
+                        help="The time requested per molecule in minutes. Note that some molecules will have several " +
+                        "protomers, so this should be well above the ~30 seconds per protomer that is typical.")
+    parser.add_argument("--array_job_name", type=str, default="building_array_job.sh",
+                        help="The name of the array job.")
+    parser.add_argument("--building_config_file", type=str, help="Optional config file for building, to override " +
+                        "default parameters.")
+    parser.add_argument("--skip_name_check", action="store_true", help="If you know your molecule names are unique, skip the checks. " +
+                        "This is useful for building lots of molecules where the set of names can take lots of memory")
+
+    args = parser.parse_args()
+    make_building_array_job(args.input_file, args.output_folder, args.bundle_size, args.minutes_per_mol,
+                            args.building_config_file, args.array_job_name, args.skip_name_check, args.scheduler, 
+                            args.container_software, args.container_path_or_name)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This makes the following changes:
- Added a way to submit building pipeline using a docker/apptainer container containing all of the software rather than unzipping on scratch everytime. This method also makes better use of linux piping rather than temporary files
- Added error handling in the strain calculation to ensure a vector has a non-zero length before normalization
- Added neutral smiles to the db2 file (docker version only right now)
- Removed protomer ID (.0,.1,etc) from the molecule name inside the DB2
- Uncomments omega force field options to align with DOCK3.8.4.9-3d which is what ZINC22 seems to be built with 